### PR TITLE
fix header inclusion issues on STM32U545 series

### DIFF
--- a/Inc/stm32u5xx_hal_nand.h
+++ b/Inc/stm32u5xx_hal_nand.h
@@ -24,6 +24,7 @@
 extern "C" {
 #endif
 
+#if defined(FMC_BANK3)
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32u5xx_ll_fmc.h"
@@ -368,6 +369,7 @@ uint32_t              HAL_NAND_Read_Status(const NAND_HandleTypeDef *hnand);
   * @}
   */
 
+#endif /* FMC_BANK3 */
 
 #ifdef __cplusplus
 }

--- a/Inc/stm32u5xx_hal_nor.h
+++ b/Inc/stm32u5xx_hal_nor.h
@@ -24,6 +24,7 @@
 extern "C" {
 #endif
 
+#if defined(FMC_BANK1)
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32u5xx_ll_fmc.h"
@@ -316,6 +317,7 @@ HAL_NOR_StatusTypeDef HAL_NOR_GetStatus(NOR_HandleTypeDef *hnor, uint32_t Addres
   * @}
   */
 
+#endif /* FMC_BANK1 */
 
 #ifdef __cplusplus
 }

--- a/Inc/stm32u5xx_hal_sram.h
+++ b/Inc/stm32u5xx_hal_sram.h
@@ -24,6 +24,7 @@
 extern "C" {
 #endif
 
+#if defined(FMC_BANK1)
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32u5xx_ll_fmc.h"
@@ -222,6 +223,7 @@ HAL_SRAM_StateTypeDef HAL_SRAM_GetState(const SRAM_HandleTypeDef *hsram);
   * @}
   */
 
+#endif /* FMC_BANK1 */
 
 #ifdef __cplusplus
 }

--- a/Inc/stm32u5xx_ll_fmc.h
+++ b/Inc/stm32u5xx_ll_fmc.h
@@ -38,6 +38,7 @@ extern "C" {
 /** @addtogroup FMC_LL_Private_Macros
   * @{
   */
+#if defined(FMC_BANK1)
 
 #define IS_FMC_NORSRAM_BANK(__BANK__) (((__BANK__) == FMC_NORSRAM_BANK1) || \
                                        ((__BANK__) == FMC_NORSRAM_BANK2) || \
@@ -95,6 +96,8 @@ extern "C" {
 #define IS_FMC_NORSRAM_EXTENDED_DEVICE(__INSTANCE__) ((__INSTANCE__) == FMC_NORSRAM_EXTENDED_DEVICE)
 #define IS_FMC_MAX_CHIP_SELECT_PULSE_TIME(__TIME__) (((__TIME__) >= 1U) && ((__TIME__) <= 65535U))
 
+#endif /* FMC_BANK1 */
+#if  defined(FMC_BANK3)
 
 #define IS_FMC_NAND_BANK(__BANK__) ((__BANK__) == FMC_NAND_BANK3)
 #define IS_FMC_WAIT_FEATURE(__FEATURE__) (((__FEATURE__) == FMC_NAND_WAIT_FEATURE_DISABLE) || \
@@ -118,6 +121,7 @@ extern "C" {
 #define IS_FMC_HIZ_TIME(__TIME__) ((__TIME__) <= 254U)
 #define IS_FMC_NAND_DEVICE(__INSTANCE__) ((__INSTANCE__) == FMC_NAND_DEVICE)
 
+#endif /* FMC_BANK3 */
 
 /**
   * @}
@@ -129,14 +133,23 @@ extern "C" {
   * @{
   */
 
+#if defined(FMC_BANK1)
 #define FMC_NORSRAM_TypeDef            FMC_Bank1_TypeDef
 #define FMC_NORSRAM_EXTENDED_TypeDef   FMC_Bank1E_TypeDef
+#endif /* FMC_BANK1 */
+#if defined(FMC_BANK3)
 #define FMC_NAND_TypeDef               FMC_Bank3_TypeDef
+#endif /* FMC_BANK3 */
 
+#if defined(FMC_BANK1)
 #define FMC_NORSRAM_DEVICE             FMC_Bank1_R
 #define FMC_NORSRAM_EXTENDED_DEVICE    FMC_Bank1E_R
+#endif /* FMC_BANK1 */
+#if defined(FMC_BANK3)
 #define FMC_NAND_DEVICE                FMC_Bank3_R
+#endif /* FMC_BANK3 */
 
+#if defined(FMC_BANK1)
 /**
   * @brief  FMC NORSRAM Configuration Structure definition
   */
@@ -261,7 +274,9 @@ typedef struct
   uint32_t AccessMode;                   /*!< Specifies the asynchronous access mode.
                                               This parameter can be a value of @ref FMC_Access_Mode                   */
 } FMC_NORSRAM_TimingTypeDef;
+#endif /* FMC_BANK1 */
 
+#if defined(FMC_BANK3)
 /**
   * @brief  FMC NAND Configuration Structure definition
   */
@@ -290,7 +305,9 @@ typedef struct
                                         delay between ALE low and RE low.
                                         This parameter can be a number between Min_Data = 0 and Max_Data = 255 */
 } FMC_NAND_InitTypeDef;
+#endif /* FMC_BANK3 */
 
+#if defined(FMC_BANK3)
 /**
   * @brief  FMC NAND Timing parameters structure definition
   */
@@ -321,6 +338,7 @@ typedef struct
                                       on the memory space timing to be configured).
                                       This parameter can be a number between Min_Data = 0 and Max_Data = 254   */
 } FMC_NAND_PCC_TimingTypeDef;
+#endif /* FMC_BANK3 */
 
 
 /**
@@ -331,6 +349,7 @@ typedef struct
 /** @addtogroup FMC_LL_Exported_Constants FMC Low Layer Exported Constants
   * @{
   */
+#if defined(FMC_BANK1)
 
 /** @defgroup FMC_LL_NOR_SRAM_Controller FMC NOR/SRAM Controller
   * @{
@@ -515,7 +534,9 @@ typedef struct
 /**
   * @}
   */
+#endif /* FMC_BANK1 */
 
+#if defined(FMC_BANK3)
 
 /** @defgroup FMC_LL_NAND_Controller FMC NAND Controller
   * @{
@@ -579,14 +600,17 @@ typedef struct
 /**
   * @}
   */
+#endif /* FMC_BANK3 */
 
 
 /** @defgroup FMC_LL_Interrupt_definition FMC Low Layer Interrupt definition
   * @{
   */
+#if defined(FMC_BANK3)
 #define FMC_IT_RISING_EDGE                      (0x00000008U)
 #define FMC_IT_LEVEL                            (0x00000010U)
 #define FMC_IT_FALLING_EDGE                     (0x00000020U)
+#endif /* FMC_BANK3 */
 /**
   * @}
   */
@@ -594,10 +618,12 @@ typedef struct
 /** @defgroup FMC_LL_Flag_definition FMC Low Layer Flag definition
   * @{
   */
+#if defined(FMC_BANK3)
 #define FMC_FLAG_RISING_EDGE                    (0x00000001U)
 #define FMC_FLAG_LEVEL                          (0x00000002U)
 #define FMC_FLAG_FALLING_EDGE                   (0x00000004U)
 #define FMC_FLAG_FEMPT                          (0x00000040U)
+#endif /* FMC_BANK3 */
 /**
   * @}
   */
@@ -614,6 +640,12 @@ typedef struct
 /** @defgroup FMC_LL_Private_Macros FMC_LL  Private Macros
   * @{
   */
+#if defined(FMC_BANK1)
+/** @defgroup FMC_LL_NOR_Macros FMC NOR/SRAM Macros
+  * @brief macros to handle NOR device enable/disable and read/write operations
+  * @{
+  */
+
 /**
   * @brief  Enable the FMC Peripheral.
   * @retval None
@@ -651,7 +683,9 @@ typedef struct
 /**
   * @}
   */
+#endif /* FMC_BANK1 */
 
+#if defined(FMC_BANK3)
 /** @defgroup FMC_LL_NAND_Macros FMC NAND Macros
   *  @brief macros to handle NAND device enable/disable
   *  @{
@@ -675,7 +709,9 @@ typedef struct
 /**
   * @}
   */
+#endif /* FMC_BANK3 */
 
+#if defined(FMC_BANK3)
 /** @defgroup FMC_LL_NAND_Interrupt FMC NAND Interrupt
   * @brief macros to handle NAND interrupts
   * @{
@@ -735,6 +771,7 @@ typedef struct
 /**
   * @}
   */
+#endif /* FMC_BANK3 */
 
 
 /**
@@ -750,6 +787,7 @@ typedef struct
   *  @{
   */
 
+#if defined(FMC_BANK1)
 /** @defgroup FMC_LL_NORSRAM  NOR SRAM
   *  @{
   */
@@ -780,7 +818,9 @@ HAL_StatusTypeDef  FMC_NORSRAM_WriteOperation_Disable(FMC_NORSRAM_TypeDef *Devic
 /**
   * @}
   */
+#endif /* FMC_BANK1 */
 
+#if defined(FMC_BANK3)
 /** @defgroup FMC_LL_NAND NAND
   *  @{
   */
@@ -810,6 +850,7 @@ HAL_StatusTypeDef  FMC_NAND_GetECC(FMC_NAND_TypeDef *Device, uint32_t *ECCval, u
 /**
   * @}
   */
+#endif /* FMC_BANK3 */
 
 
 


### PR DESCRIPTION
Resolves https://github.com/STMicroelectronics/stm32u5xx_hal_driver/issues/6

In trying to get Zephyr RTOS working on the Nucleo U545RE-Q board, I discovered header inclusion issues building the HAL for the STM32U545 SoC.

Zephyr RTOS makes use of the "stm32u5xx_hal_driver" for some interactions with the ST hardware, and builds the HAL by copying the default "stm32_hal_conf_template.h" to "stm32_hal_conf.h", leaving all options enabled.

However, some of the modules (specifically HAL_SRAM_MODULE_ENABLED, HAL_NAND_MODULE_ENABLED and HAL_NOR_MODULE_ENABLED) do not compile for the STM32U545. Based on recommendations from a engineer in the Zephyr forums, I modeled changes to four files ((stm32u5xx_hal_sram.h, stm32u5xx_hal_nor.h, stm32u5xx_hal_nand.h and stm32u5xx_ll_fmc.h) with appropriate "#ifdef" checks using the example for the "stm32g4xx_hal_driver", and this allows the code to build for the U545 series.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/stm32u5xx_hal_driver/blob/main/CONTRIBUTING.md) file.
